### PR TITLE
Rename method for clarity and update references

### DIFF
--- a/SmartClinic.Application/Features/Doctors/Mapper/DoctorMappingExtensions.cs
+++ b/SmartClinic.Application/Features/Doctors/Mapper/DoctorMappingExtensions.cs
@@ -5,7 +5,7 @@ namespace SmartClinic.Application.Features.Doctors.Mapper;
 public static class DoctorMappingExtensions
 {
 
-    public static GetDoctorWithAvailableAppointment ToGetDoctorWithAvailableAppointment(this Doctor doctor, List<AvailableSchedule> AvailableSchedules)
+    public static GetDoctorWithAvailableAppointment ToGetDoctorWithAvailableSchedules(this Doctor doctor, List<AvailableSchedule> AvailableSchedules)
     {
         return new GetDoctorWithAvailableAppointment
         (

--- a/SmartClinic.Application/Services/Implementation/DoctorService.cs
+++ b/SmartClinic.Application/Services/Implementation/DoctorService.cs
@@ -225,7 +225,7 @@ public class DoctorService : ResponseHandler, IDoctorService
 
         AvailableSchedules = AddingDaySlots(doctor, AvailableSchedules);
 
-        var result = doctor.ToGetDoctorWithAvailableAppointment(AvailableSchedules);
+        var result = doctor.ToGetDoctorWithAvailableSchedules(AvailableSchedules);
 
         return Success(result, "Found");
     }


### PR DESCRIPTION
Changed method name from `ToGetDoctorWithAvailableAppointment` to `ToGetDoctorWithAvailableSchedules` in `DoctorMappingExtensions` for better clarity. Updated the corresponding call in `DoctorService` to ensure functionality remains intact.