### PR TITLE
Remove TimeSlot property and related validations

### DIFF
--- a/SmartClinic.Application/Features/Appointments/Command/CreateAppointment/CreateAppointmentDto.cs
+++ b/SmartClinic.Application/Features/Appointments/Command/CreateAppointment/CreateAppointmentDto.cs
@@ -3,7 +3,6 @@ public class CreateAppointmentDto
 {
     public int DoctorId { get; set; }
     public int SpecializationId { get; set; }
-    public int TimeSlot { get; set; }
     public DateOnly AppointmentDate { get; set; }
     public TimeOnly StartTime { get; set; }
 }

--- a/SmartClinic.Application/Features/Appointments/Command/CreateAppointment/CreateAppointmentValidator.cs
+++ b/SmartClinic.Application/Features/Appointments/Command/CreateAppointment/CreateAppointmentValidator.cs
@@ -15,11 +15,6 @@ public class CreateAppointmentValidator : AbstractValidator<CreateAppointmentDto
          .NotEmpty();
 
 
-        RuleFor(x => x.TimeSlot)
-        .GreaterThanOrEqualTo(0)
-        .LessThanOrEqualTo(60)
-        .NotEmpty();
-
         RuleFor(x => x.DoctorId)
          .MustAsync(DoctorExists).WithMessage("Invalid Doctor Id")
          .NotEmpty();
@@ -29,8 +24,6 @@ public class CreateAppointmentValidator : AbstractValidator<CreateAppointmentDto
 
         RuleFor(x => x)
             .MustAsync(IsValidDoctorSpecialization).WithMessage("Invalid Doctor Specialization Id")
-            .MustAsync(ValidAppointment).WithMessage("Appointment already reserved or invalid inserted data");
-
 
         this._unitOfWork = unitOfWork;
     }
@@ -40,15 +33,7 @@ public class CreateAppointmentValidator : AbstractValidator<CreateAppointmentDto
         => await _unitOfWork.Repository<IDoctorRepository>().
                      IsValidDoctorSpecialization(dto.SpecializationId, dto.DoctorId);
 
-    private async Task<bool> ValidAppointment(CreateAppointmentDto dto, CancellationToken token)
-    {
-        var doctor = await _unitOfWork.Repository<IDoctorRepository>()
-            .GetDoctorWithSpecificScheduleAsync(dto.DoctorId, dto.AppointmentDate,
-            dto.StartTime, dto.TimeSlot);
-        if (doctor is null || doctor.DoctorSchedules.Count == 0 || doctor.Appointments.Count > 0) return false;
 
-        return true;
-    }
 
     private async Task<bool> DoctorExists(int DoctorId, CancellationToken token)
          => await _unitOfWork.Repository<IDoctorRepository>().ExistsAsync(DoctorId);

--- a/SmartClinic.Application/Features/Appointments/Mapper/AppointmentMappingExtension.cs
+++ b/SmartClinic.Application/Features/Appointments/Mapper/AppointmentMappingExtension.cs
@@ -57,11 +57,11 @@ public static class AppointmentMappingExtension
         );
     }
 
-    public static Appointment ToEntity(this CreateAppointmentDto appointmentDto, int patientId)
+    public static Appointment ToEntity(this CreateAppointmentDto appointmentDto, int patientId, int timeSlot)
         => new()
         {
             Duration = new(appointmentDto.StartTime,
-            appointmentDto.StartTime.AddMinutes(appointmentDto.TimeSlot)),
+            appointmentDto.StartTime.AddMinutes(timeSlot)),
             AppointmentDate = appointmentDto.AppointmentDate,
             DoctorId = appointmentDto.DoctorId,
             PatientId = patientId,

--- a/SmartClinic.Infrastructure/Interfaces/IDoctorRepository.cs
+++ b/SmartClinic.Infrastructure/Interfaces/IDoctorRepository.cs
@@ -2,7 +2,7 @@
 public interface IDoctorRepository : IRepository<Doctor>
 {
     Task<bool> ExistsAsync(int doctorId);
-    Task<Doctor?> GetDoctorWithSpecificScheduleAsync(int doctorId, DateOnly appointmentDate, TimeOnly startTime, int timeSlot);
+    Task<Doctor?> GetDoctorWithSpecificScheduleAsync(int doctorId, DateOnly appointmentDate, TimeOnly startTime);
     Task<Doctor?> GetWithAppointmentsAsync(int id, DateOnly startDate);
     Task<bool> IsValidDoctorSpecialization(int specializationId, int doctorId);
 }

--- a/SmartClinic.Infrastructure/Repos/DoctorRepository.cs
+++ b/SmartClinic.Infrastructure/Repos/DoctorRepository.cs
@@ -22,13 +22,12 @@ public class DoctorRepository(ApplicationDbContext context)
         => base.GetSingleAsync(x => x.Id == id && x.IsActive, false,
               nameof(Doctor.User), nameof(Doctor.Specialization));
 
-    public async Task<Doctor?> GetDoctorWithSpecificScheduleAsync(int doctorId, DateOnly appointmentDate, TimeOnly startTime, int timeSlot)
+    public async Task<Doctor?> GetDoctorWithSpecificScheduleAsync(int doctorId, DateOnly appointmentDate, TimeOnly startTime)
     {
         return await context.Doctors.AsNoTracking()
                 .Where(x => x.Id == doctorId && x.IsActive)
                 .Include(x => x.DoctorSchedules
                             .Where(s => s.DayOfWeek == appointmentDate.DayOfWeek &&
-                            s.SlotDuration == timeSlot &&
                              s.StartTime <= startTime &&
                              s.EndTime >= startTime.AddMinutes(s.SlotDuration)))
                 .Include(x => x.Appointments
@@ -36,6 +35,7 @@ public class DoctorRepository(ApplicationDbContext context)
                             a.Duration.StartTime <= startTime &&
                             a.Duration.EndTime > startTime))
                 .FirstOrDefaultAsync();
+
     }
 
     public async Task<Doctor?> GetWithAppointmentsAsync(int id, DateOnly startDate)


### PR DESCRIPTION
This commit removes the `TimeSlot` property from the `CreateAppointmentDto` class and updates the associated validation rules in `CreateAppointmentValidator`. The `ToEntity` method in `AppointmentMappingExtension` now accepts a `timeSlot` parameter, and the appointment creation logic in `AppointmentService` has been modified to check the doctor's schedule before creating an appointment. Additionally, the `IDoctorRepository` and `DoctorRepository` interfaces have been updated to reflect these changes by removing the `timeSlot` parameter from the `GetDoctorWithSpecificScheduleAsync` method.