### PR TITLE
Add delete schedule command and update response types

### DIFF
--- a/SmartClinic.API/Controllers/DoctorScheduleController .cs
+++ b/SmartClinic.API/Controllers/DoctorScheduleController .cs
@@ -1,7 +1,7 @@
 ﻿using SmartClinic.Application.Bases;
 using SmartClinic.Application.Features.DoctorSchedule.Command.CreateDoctorSchedule;
+using SmartClinic.Application.Features.DoctorSchedule.Command.DeleteDoctorSchedule;
 using SmartClinic.Application.Features.DoctorSchedule.Command.UpdateDoctorSchedule; // إضافة هذا الـ namespace
-using SmartClinic.Application.Features.DoctorSchedule.Command.UpdateDoctorSchedule.SmartClinic.Application.Features.DoctorSchedule.Command.UpdateDoctorSchedule;
 using SmartClinic.Application.Features.DoctorSchedule.Query.DTOs.GetDoctorSchedule;
 
 
@@ -34,46 +34,32 @@ public class DoctorScheduleController : AppControllerBase
     }
 
     [HttpDelete("{scheduleId}")]
-    [ProducesResponseType<Response<string>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<Response<DeleteSchedulesResponse>>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteScheduleById(int scheduleId)
     {
         var response = await _doctorScheduleService.DeleteScheduleByIdAsync(scheduleId);
 
-        if (!response.IsSuccessful)
-        {
-            return NotFound(new { message = response.Message });
-        }
-
-        return NewResult(new SmartClinic.Application.Bases.Response<string>
-        {
-            Message = response.Message
-        });
+        return NewResult(response);
     }
 
     [HttpPost]
-    [ProducesResponseType<Response<string>>(StatusCodes.Status201Created)]
-    [ProducesResponseType<Response<string>>(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType<Response<GetDoctorSchedule>>(StatusCodes.Status201Created)]
     public async Task<IActionResult> CreateDoctorSchedule([FromBody] CreateDoctorScheduleRequest request)
     {
         var response = await _doctorScheduleService.CreateAsync(request);
 
-        return NewResult(new SmartClinic.Application.Bases.Response<CreateDoctorScheduleResponse>
-        {
-            Data = response,
-            Message = "Schedule created successfully"
-        });
+        return NewResult(response);
+
     }
 
     [HttpPut("{scheduleId}")]
+    [ProducesResponseType<Response<GetDoctorSchedule>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<Response<GetDoctorSchedule>>(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> UpdateDoctorSchedule(int scheduleId, [FromBody] UpdateDoctorScheduleRequest request)
     {
         var response = await _doctorScheduleService.UpdateAsync(request);
 
-        return NewResult(new SmartClinic.Application.Bases.Response<UpdateDoctorScheduleResponse>
-        {
-            Data = response,
-            Message = response.Message
-        });
+        return NewResult(response);
     }
 }

--- a/SmartClinic.Application/Features/DoctorsSchedules/Command/CreateDoctorSchedule/CreateDoctorScheduleResponse.cs
+++ b/SmartClinic.Application/Features/DoctorsSchedules/Command/CreateDoctorSchedule/CreateDoctorScheduleResponse.cs
@@ -1,13 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace SmartClinic.Application.Features.DoctorsSchedules.Command.CreateDoctorSchedule;
 
-namespace SmartClinic.Application.Features.DoctorSchedule.Command.CreateDoctorSchedule
-{
-    public record CreateDoctorScheduleResponse(
-      int Id,
-      string Message = "Schedule created successfully"
-  );
-}
+public record CreateDoctorScheduleResponse(
+  int Id,
+  string Message = "Schedule created successfully"
+);

--- a/SmartClinic.Application/Services/Interfaces/IDoctorSchedule.cs
+++ b/SmartClinic.Application/Services/Interfaces/IDoctorSchedule.cs
@@ -1,19 +1,17 @@
 ﻿using SmartClinic.Application.Features.DoctorSchedule.Command.CreateDoctorSchedule;
 using SmartClinic.Application.Features.DoctorSchedule.Command.DeleteDoctorSchedule;
 using SmartClinic.Application.Features.DoctorSchedule.Command.UpdateDoctorSchedule;
-using SmartClinic.Application.Features.DoctorSchedule.Command.UpdateDoctorSchedule.SmartClinic.Application.Features.DoctorSchedule.Command.UpdateDoctorSchedule;
 using SmartClinic.Application.Features.DoctorSchedule.Query.DTOs.GetDoctorSchedule;
 
-namespace SmartClinic.Application.Services.Interfaces
+namespace SmartClinic.Application.Services.Interfaces;
+
+public interface IDoctorScheduleService
 {
-    public interface IDoctorScheduleService
-    {
-        Task<Response<IEnumerable<GetDoctorSchedule>>> GetSchedulesForDoctorAsync(int doctorId);
+    Task<Response<IEnumerable<GetDoctorSchedule>>> GetSchedulesForDoctorAsync(int doctorId);
 
-        Task<DeleteSchedulesResponse> DeleteScheduleByIdAsync(int scheduleId);
+    Task<Response<DeleteSchedulesResponse>> DeleteScheduleByIdAsync(int scheduleId);
 
-        Task<CreateDoctorScheduleResponse> CreateAsync(CreateDoctorScheduleRequest request);
+    Task<Response<GetDoctorSchedule>> CreateAsync(CreateDoctorScheduleRequest request);
 
-        Task<UpdateDoctorScheduleResponse> UpdateAsync(UpdateDoctorScheduleRequest request);
-    }
+    Task<Response<GetDoctorSchedule>> UpdateAsync(UpdateDoctorScheduleRequest request);
 }


### PR DESCRIPTION
This commit introduces a new command for deleting doctor schedules and updates the response types across various methods in the controller and service classes.

Key changes include:
- Added `DeleteDoctorSchedule` command in `DoctorScheduleController.cs` and updated `DeleteScheduleById` to return `Response<DeleteSchedulesResponse>`.
- Modified `CreateDoctorSchedule` and `UpdateDoctorSchedule` methods to return more specific response types.
- Corrected namespace and simplified record definition in `CreateDoctorScheduleResponse.cs`.
- Updated `DoctorScheduleServices.cs` to inherit from `ResponseHandler` and adjusted methods to return `Response<T>` types for consistency.
- Reflected these changes in the `IDoctorScheduleService` interface to align with the new response structures.