### PR TITLE
Add Testing project with unit tests for API controllers

### DIFF
--- a/SmartClinic.sln
+++ b/SmartClinic.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartClinic.Domain", "Smart
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmartClinic.Infrastructure", "SmartClinic.Infrastructure\SmartClinic.Infrastructure.csproj", "{5FF82C95-19FF-7FD3-863C-249E3238DD2E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testing", "Testing\Testing.csproj", "{73FD3D66-670E-4838-865A-BAE3ABB4E57D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -39,6 +41,10 @@ Global
 		{5FF82C95-19FF-7FD3-863C-249E3238DD2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5FF82C95-19FF-7FD3-863C-249E3238DD2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5FF82C95-19FF-7FD3-863C-249E3238DD2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73FD3D66-670E-4838-865A-BAE3ABB4E57D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73FD3D66-670E-4838-865A-BAE3ABB4E57D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73FD3D66-670E-4838-865A-BAE3ABB4E57D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73FD3D66-670E-4838-865A-BAE3ABB4E57D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Testing/Controllers/AppointmentsControllerTests.cs
+++ b/Testing/Controllers/AppointmentsControllerTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SmartClinic.API.Controllers;
+using SmartClinic.Application.Bases;
+using SmartClinic.Application.Features.Appointments.Command.CreateAppointment;
+using SmartClinic.Application.Services.Interfaces;
+using System.Net;
+using System.Security.Claims;
+
+namespace Testing.Controllers;
+
+public class AppointmentsControllerTests
+{
+    private readonly Mock<IAppointmentService> _mockAppointmentService;
+    private readonly AppointmentsController _controller;
+
+    public AppointmentsControllerTests()
+    {
+        _mockAppointmentService = new Mock<IAppointmentService>();
+        _controller = new AppointmentsController(_mockAppointmentService.Object);
+
+        // Setup default user claims to mock authorization
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "1"),
+            new Claim(ClaimTypes.Role, "patient")
+        }, "mock"));
+
+        // Set up controller context with the mocked user
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = user }
+        };
+    }
+
+    [Fact]
+    public async Task CreateAppointment_ValidRequest_ReturnsCreatedResult()
+    {
+        // Arrange
+        var appointmentDto = new CreateAppointmentDto
+        {
+            DoctorId = 1,
+            SpecializationId = 2,
+            AppointmentDate = DateOnly.FromDateTime(DateTime.Today.AddDays(1)),
+            StartTime = TimeOnly.FromTimeSpan(new TimeSpan(10, 0, 0))
+        };
+
+        var expectedResponse = new Response<string>
+        {
+            StatusCode = HttpStatusCode.Created,
+            Message = "Created",
+            Data = "Created"
+        };
+
+        _mockAppointmentService
+            .Setup(service => service.CreateAppointmentAsync(
+                It.IsAny<CreateAppointmentDto>(),
+                It.IsAny<int>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.CreateAppointment(appointmentDto);
+
+        // Assert
+        var createdResult = Assert.IsType<CreatedResult>(result);
+        Assert.Equal(StatusCodes.Status201Created, createdResult.StatusCode);
+
+        var response = Assert.IsType<Response<string>>(createdResult.Value);
+        Assert.Equal("Created", response.Data);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        // Verify the service was called with correct parameters
+        _mockAppointmentService.Verify(
+            service => service.CreateAppointmentAsync(
+                It.Is<CreateAppointmentDto>(dto =>
+                    dto.DoctorId == appointmentDto.DoctorId &&
+                    dto.SpecializationId == appointmentDto.SpecializationId),
+                1), // PatientId from the mocked user claims
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAppointment_InvalidRequest_ReturnsBadRequest()
+    {
+        // Arrange
+        var appointmentDto = new CreateAppointmentDto
+        {
+            DoctorId = 1,
+            SpecializationId = 2,
+            AppointmentDate = DateOnly.FromDateTime(DateTime.Today.AddDays(1)),
+            StartTime = TimeOnly.FromTimeSpan(new TimeSpan(10, 0, 0))
+        };
+
+        var expectedResponse = new Response<string>
+        {
+            StatusCode = HttpStatusCode.BadRequest,
+            Message = "Error",
+            Errors = new List<string> { "Appointment not available" }
+        };
+
+        _mockAppointmentService
+            .Setup(service => service.CreateAppointmentAsync(
+                It.IsAny<CreateAppointmentDto>(),
+                It.IsAny<int>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.CreateAppointment(appointmentDto);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, badRequestResult.StatusCode);
+
+        var response = Assert.IsType<Response<string>>(badRequestResult.Value);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.NotNull(response.Errors);
+        Assert.Contains("Appointment not available", response.Errors);
+    }
+
+    [Fact]
+    public async Task CreateAppointment_ServiceThrowsException_ReturnsInternalServerError()
+    {
+        // Arrange
+        var appointmentDto = new CreateAppointmentDto
+        {
+            DoctorId = 1,
+            SpecializationId = 2,
+            AppointmentDate = DateOnly.FromDateTime(DateTime.Today.AddDays(1)),
+            StartTime = TimeOnly.FromTimeSpan(new TimeSpan(10, 0, 0))
+        };
+
+        _mockAppointmentService
+            .Setup(service => service.CreateAppointmentAsync(
+                It.IsAny<CreateAppointmentDto>(),
+                It.IsAny<int>()))
+            .ThrowsAsync(new Exception("Unexpected error"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Exception>(() => _controller.CreateAppointment(appointmentDto));
+    }
+}

--- a/Testing/Testing.csproj
+++ b/Testing/Testing.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SmartClinic.API\SmartClinic.API.csproj" />
+    <ProjectReference Include="..\SmartClinic.Application\SmartClinic.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Testing/UnitTest1.cs
+++ b/Testing/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace Testing;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}


### PR DESCRIPTION
- Introduced a new "Testing" project in the solution.
- Created `Testing.csproj` targeting .NET 9.0 with necessary testing packages.
- Added `UnitTest1` class with a placeholder test method.
- Implemented `AppointmentsControllerTests` to validate `CreateAppointment` method behavior.
- Utilized Moq for mocking `IAppointmentService` in tests.