### PR TITLE
Add pagination support and soft delete functionality

### DIFF
--- a/SmartClinic.Application/Bases/Pagination.cs
+++ b/SmartClinic.Application/Bases/Pagination.cs
@@ -1,0 +1,9 @@
+﻿namespace SmartClinic.Application.Bases;
+public class Pagination<T>(int pageIndex, int pageSize, int count, IReadOnlyList<T> data)
+{
+    public int PageIndex { get; set; } = pageIndex;
+    public int PageSize { get; set; } = pageSize;
+    public int TotalPages { get; set; } = (int)Math.Floor((decimal)(count / pageSize));
+    public int Total { get; set; } = count;
+    public IReadOnlyList<T> Data { get; set; } = data;
+}

--- a/SmartClinic.Application/Bases/PagingParams.cs
+++ b/SmartClinic.Application/Bases/PagingParams.cs
@@ -1,0 +1,7 @@
+﻿namespace SmartClinic.Application.Bases;
+public class PagingParams
+{
+    public int PageIndex { get; set; }
+    public int PageSize { get; set; }
+
+}

--- a/SmartClinic.Application/ModuleAddApplicationDependencies.cs
+++ b/SmartClinic.Application/ModuleAddApplicationDependencies.cs
@@ -28,6 +28,11 @@ public static class ModuleAddApplicationDependencies
         services.AddScoped<IFetchProfile, FetchDoctorProfile>();
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<IFileHandlerService, FileHandler>();
+
+        services.AddTransient(typeof(IPagedCreator<>), typeof(PagedCreator<>));
+
+
+
         return services;
     }
 }

--- a/SmartClinic.Application/Services/Implementation/PagedCreator.cs
+++ b/SmartClinic.Application/Services/Implementation/PagedCreator.cs
@@ -1,0 +1,20 @@
+﻿namespace SmartClinic.Application.Services.Implementation;
+public class PagedCreator<T> : IPagedCreator<T>
+    where T : BaseEntity
+{
+
+
+    async Task<Pagination<T>> IPagedCreator<T>.CreatePagedResult(IRepository<T> repo, int pageIndex, int pageSize,
+        IReadOnlyList<T> data)
+    {
+        var count = await repo.CountAsync();
+        return new Pagination<T>(pageIndex, pageSize, count, data);
+    }
+
+    async Task<Pagination<TDto>> IPagedCreator<T>.CreatePagedResult<TDto>(IRepository<T> repo, int pageIndex, int pageSize,
+        IReadOnlyList<TDto> data)
+    {
+        var count = await repo.CountAsync();
+        return new Pagination<TDto>(pageIndex, pageSize, count, data);
+    }
+}

--- a/SmartClinic.Application/Services/Interfaces/IPagedCreator.cs
+++ b/SmartClinic.Application/Services/Interfaces/IPagedCreator.cs
@@ -1,0 +1,9 @@
+﻿namespace SmartClinic.Application.Services.Interfaces;
+public interface IPagedCreator<T>
+    where T : BaseEntity
+{
+    Task<Pagination<T>> CreatePagedResult(IRepository<T> repo, int pageIndex, int pageSize, IReadOnlyList<T> data);
+
+    Task<Pagination<TDto>> CreatePagedResult<TDto>(IRepository<T> repo, int pageIndex, int pageSize, IReadOnlyList<TDto> data);
+
+}

--- a/SmartClinic.Infrastructure/Data/ApplicationDbContext.cs
+++ b/SmartClinic.Infrastructure/Data/ApplicationDbContext.cs
@@ -18,9 +18,51 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+
         // Apply separate configuration classes
         builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
+    }
+
+
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+
+
+        #region Doctor
+        foreach (var entry in base.ChangeTracker.Entries<Doctor>()
+            .Where(x => x.State.Equals(EntityState.Deleted)))
+        {
+            entry.State = EntityState.Modified;
+            entry.Entity.IsActive = false;
+            entry.Entity.User.IsActive = false;
+            entry.Entity.User.Email = null;
+        }
+        #endregion
+
+        #region Patient
+        foreach (var entry in base.ChangeTracker.Entries<Patient>()
+            .Where(x => x.State.Equals(EntityState.Deleted)))
+        {
+            entry.State = EntityState.Modified;
+            entry.Entity.IsActive = false;
+            entry.Entity.User.IsActive = false;
+            entry.Entity.User.Email = null;
+        }
+        #endregion
+
+        #region Specialization
+        foreach (var entry in base.ChangeTracker.Entries<Specialization>()
+            .Where(x => x.State.Equals(EntityState.Deleted)))
+        {
+            entry.State = EntityState.Modified;
+            entry.Entity.IsActive = false;
+        }
+        #endregion
+
+
+
+        return base.SaveChangesAsync(cancellationToken);
     }
 
 }

--- a/SmartClinic.Infrastructure/Interfaces/IRepository.cs
+++ b/SmartClinic.Infrastructure/Interfaces/IRepository.cs
@@ -13,7 +13,12 @@ public interface IRepository<T> where T : BaseEntity
 
     Task<IEnumerable<T>> ListNoTrackingAsync(int pageSize = 20, int pageIndex = 1);
 
+    Task<IEnumerable<TDto>> ListNoTrackingAsync<TDto>(int pageSize = 20, int pageIndex = 1, string? orderBy = null,
+        bool descending = false, bool isDistinct = false);
+
     Task<bool> SoftDeleteAsync(int id);
+
+    Task<int> CountAsync();
 
     Task AddAsync(T entity);
 

--- a/SmartClinic.Infrastructure/QueryHandler.cs
+++ b/SmartClinic.Infrastructure/QueryHandler.cs
@@ -7,7 +7,7 @@ public static class QueryHandler
 {
     public static IQueryable<T> GetQuery<T>(this IQueryable<T> query, Expression<Func<T, bool>>? criteria = null,
         int? pageSize = null, int? pageIndex = null, bool withTracking = true, string? orderBy = null,
-        bool descending = true, bool isDistinct = false, params string[] includes)
+        bool descending = false, bool isDistinct = false, params string[] includes)
         where T : BaseEntity
     {
 
@@ -60,7 +60,7 @@ public static class QueryHandler
 
     public static IQueryable<TResult> GetQuery<T, TResult>(this IQueryable<T> query, Expression<Func<T, bool>>? criteria = null,
          Expression<Func<T, TResult>> select = null!, int? pageSize = null, int? pageIndex = null, string? orderBy = null,
-        bool descending = true, bool isDistinct = false)
+        bool descending = false, bool isDistinct = false)
         where T : BaseEntity
     {
         query = query.GetQuery(criteria, pageSize, pageIndex, false, orderBy, descending


### PR DESCRIPTION
- Updated `ModuleAddApplicationDependencies` to register `IPagedCreator<>` as a transient service.
- Modified `ApplicationDbContext` to apply configurations and added `SaveChangesAsync` for soft deletes of `Doctor`, `Patient`, and `Specialization`.
- Extended `IRepository<T>` with `ListNoTrackingAsync<TDto>`, `SoftDeleteAsync`, and `CountAsync` methods.
- Changed default `descending` parameter in `GetQuery` method of `QueryHandler` to `false`.
- Introduced `Pagination<T>` class for encapsulating pagination details.
- Added `PagingParams` class for pagination parameters.
- Created `PagedCreator<T>` class implementing `IPagedCreator<T>` for paged result creation.
- Defined `IPagedCreator<T>` interface for paged result contracts.